### PR TITLE
bugfix: call command ask you to choose between two identical numbers

### DIFF
--- a/app/src/main/java/com/coderGtm/yantra/Utils.kt
+++ b/app/src/main/java/com/coderGtm/yantra/Utils.kt
@@ -102,8 +102,9 @@ fun contactsManager(terminal: Terminal, callingIntent: Boolean = false, callTo: 
                             cursorPhone.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER))
                         builder.add(Contacts(name,phoneNumValue))
                         terminal.contactNames.add(name)
-                        if (callingIntent && callTo == name.lowercase() && !callingCandidates.contains(phoneNumValue)) {
-                            callingCandidates.add(phoneNumValue)
+                        val phoneNumValueStandardized  = phoneNumValue.filter { !it.isWhitespace() }
+                        if (callingIntent && callTo == name.lowercase() && !callingCandidates.contains(phoneNumValueStandardized)) {
+                            callingCandidates.add(phoneNumValueStandardized)
                         }
                     }
                 }

--- a/app/src/main/java/com/coderGtm/yantra/Utils.kt
+++ b/app/src/main/java/com/coderGtm/yantra/Utils.kt
@@ -102,7 +102,7 @@ fun contactsManager(terminal: Terminal, callingIntent: Boolean = false, callTo: 
                             cursorPhone.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER))
                         builder.add(Contacts(name,phoneNumValue))
                         terminal.contactNames.add(name)
-                        val phoneNumValueStandardized  = phoneNumValue.filter { !it.isWhitespace() }
+                        val phoneNumValueStandardized  = phoneNumValue.filterNot { it.isWhitespace() }
                         if (callingIntent && callTo == name.lowercase() && !callingCandidates.contains(phoneNumValueStandardized)) {
                             callingCandidates.add(phoneNumValueStandardized)
                         }


### PR DESCRIPTION
For some contacts, when I use the call command I am requested to choose between two numbers but they are actually two times the same number. See screenshots bellow. I solved the issue by adding few lines of code in order to remove whitespaces in phone numbers.

P.S. : What is causing this number duplicate is not fully clear for me. It is not happening for every contact, it looks like it may be due to the association of the contact with whatsapp.
P.S.S. : I am new to Kotlin, so the way I did it is maybe not super clean. Do not hesitate to give me feedback 
![Screenshot_20240520_162748](https://github.com/coderGtm/yantra-app-launcher/assets/36671181/0c3d61c4-c509-4b78-b446-c75de01a70fe)
![Screenshot_20240520_162832](https://github.com/coderGtm/yantra-app-launcher/assets/36671181/b0a74273-012f-4ffd-b043-40f11e7c0d6c)
