### PR TITLE
Add source-distributed plugin system with inline autocomplete

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,11 +62,17 @@ android {
         compose true
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     namespace 'com.coderGtm.yantra'
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        jvmTarget = "11"
+    }
 }
 
 dependencies {

--- a/app/src/main/java/com/coderGtm/yantra/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/coderGtm/yantra/activities/SettingsActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -49,6 +50,8 @@ import com.coderGtm.yantra.misc.openUsernamePrefixSetter
 import com.coderGtm.yantra.activities.helpers.openFontSelector
 import com.coderGtm.yantra.activities.helpers.openLanguagePicker
 import com.coderGtm.yantra.activities.helpers.openSoundEffectsList
+import com.coderGtm.yantra.plugins.PluginManager
+import com.coderGtm.yantra.plugins.YantraPlugin
 import com.coderGtm.yantra.toast
 import com.coderGtm.yantra.ui.components.containers.SettingsScreen
 import com.coderGtm.yantra.ui.settings.groups.AiGroup
@@ -59,6 +62,8 @@ import com.coderGtm.yantra.ui.settings.groups.FontGroup
 import com.coderGtm.yantra.ui.settings.groups.GesturesGroup
 import com.coderGtm.yantra.ui.settings.groups.KeyboardGroup
 import com.coderGtm.yantra.ui.settings.groups.OtherGroup
+import com.coderGtm.yantra.ui.settings.groups.PluginManagerDialog
+import com.coderGtm.yantra.ui.settings.groups.PluginsGroup
 import com.coderGtm.yantra.ui.settings.groups.PromptGroup
 import com.coderGtm.yantra.ui.settings.groups.SuggestionsGroup
 import com.coderGtm.yantra.ui.settings.groups.TermuxGroup
@@ -84,6 +89,7 @@ class SettingsActivity : AppCompatActivity() {
     private var hideKeyboardOnEnter          by mutableStateOf(true)
     private var actOnSuggestionTap           by mutableStateOf(false)
     private var actOnLastSecondarySuggestion by mutableStateOf(false)
+    private var showPluginManager            by mutableStateOf(false)
     private var initCmdLog                   by mutableStateOf(false)
     private var useModernPromptDesign        by mutableStateOf(false)
     private var disableAds                   by mutableStateOf(false)
@@ -96,6 +102,8 @@ class SettingsActivity : AppCompatActivity() {
     private var usernamePrefix               by mutableStateOf("$")
 
     private val isProUser by lazy { isPro(this) }
+    private val builtInPlugins by lazy { PluginManager.builtInPlugins() }
+    private val pluginEnabledStates = mutableStateMapOf<String, Boolean>()
 
     internal val supportedLocales = mapOf(
         "English"    to "en",
@@ -188,6 +196,10 @@ class SettingsActivity : AppCompatActivity() {
         hideKeyboardOnEnter              = preferenceObject.getBoolean("hideKeyboardOnEnter", true)
         actOnSuggestionTap               = preferenceObject.getBoolean("actOnSuggestionTap", false)
         actOnLastSecondarySuggestion     = preferenceObject.getBoolean("actOnLastSecondarySuggestion", false)
+        pluginEnabledStates.clear()
+        builtInPlugins.forEach { plugin ->
+            pluginEnabledStates[plugin.preferenceKey] = plugin.isEnabled(preferenceObject)
+        }
         initCmdLog                       = preferenceObject.getBoolean("initCmdLog", false)
         useModernPromptDesign            = preferenceObject.getBoolean("useModernPromptDesign", false)
         disableAds                       = preferenceObject.getBoolean("disableAds", false)
@@ -259,6 +271,23 @@ class SettingsActivity : AppCompatActivity() {
                 onActOnLastSecondarySuggestionChange = { actOnLastSecondarySuggestion = it; preferenceEditObject.putBoolean("actOnLastSecondarySuggestion", it).apply(); changedSettingsCallback(this@SettingsActivity) }
             )
 
+            PluginsGroup(
+                enabledPluginCount = builtInPlugins.count { isPluginEnabled(it) },
+                installedPluginCount = builtInPlugins.size,
+                onOpenPluginManager = { showPluginManager = true }
+            )
+
+            if (showPluginManager) {
+                PluginManagerDialog(
+                    plugins = builtInPlugins,
+                    isPluginEnabled = { isPluginEnabled(it) },
+                    onPluginEnabledChange = { plugin, enabled ->
+                        setPluginEnabled(plugin, enabled)
+                    },
+                    onDismiss = { showPluginManager = false }
+                )
+            }
+
             GesturesGroup(
                 isProUser                    = isProUser,
                 onOpenDoubleTapActionSetter  = { openDoubleTapActionSetter(this@SettingsActivity, preferenceObject, preferenceEditObject) },
@@ -309,5 +338,20 @@ class SettingsActivity : AppCompatActivity() {
                 onOpenNewsWebsiteSetter    = { openNewsWebsiteSetter(this@SettingsActivity, preferenceObject, preferenceEditObject) }
             )
         }
+    }
+
+    private fun isPluginEnabled(plugin: YantraPlugin): Boolean {
+        return pluginEnabledStates[plugin.preferenceKey]
+            ?: preferenceObject.getBoolean(plugin.preferenceKey, plugin.defaultEnabled)
+    }
+
+    private fun setPluginEnabled(plugin: YantraPlugin, enabled: Boolean) {
+        if (!PluginManager.compatibilityFor(plugin).canEnable) {
+            return
+        }
+
+        pluginEnabledStates[plugin.preferenceKey] = enabled
+        preferenceEditObject.putBoolean(plugin.preferenceKey, enabled).apply()
+        changedSettingsCallback(this@SettingsActivity)
     }
 }

--- a/app/src/main/java/com/coderGtm/yantra/plugins/PluginCatalog.kt
+++ b/app/src/main/java/com/coderGtm/yantra/plugins/PluginCatalog.kt
@@ -1,0 +1,27 @@
+package com.coderGtm.yantra.plugins
+
+import com.coderGtm.yantra.plugins.contrib.autocomplete_yyppsk_v0_1_0.InlineAutocompletePlugin
+
+/**
+ * Registry for source-distributed plugins that ship with the app.
+ *
+ * Contribution path:
+ * 1. Add plugin source under:
+ *    plugins/contrib/<feature>_<githubUsername>_<version>/
+ *    Example: plugins/contrib/autocomplete_yyppsk_v0_1_0/
+ * 2. Keep all plugin-specific files inside that folder whenever possible.
+ * 3. Register the plugin constructor here so Yantra can discover it.
+ *
+ * This keeps plugin contributions isolated while avoiding dynamic code loading.
+ */
+object PluginCatalog {
+    private val cachedSourceDistributedPlugins: List<YantraPlugin> by lazy {
+        listOf(
+            InlineAutocompletePlugin()
+        )
+    }
+
+    fun sourceDistributedPlugins(): List<YantraPlugin> {
+        return cachedSourceDistributedPlugins
+    }
+}

--- a/app/src/main/java/com/coderGtm/yantra/plugins/PluginManager.kt
+++ b/app/src/main/java/com/coderGtm/yantra/plugins/PluginManager.kt
@@ -1,0 +1,75 @@
+package com.coderGtm.yantra.plugins
+
+import android.content.SharedPreferences
+import android.util.Log
+import com.coderGtm.yantra.terminal.Terminal
+
+class PluginManager(private val preferenceObject: SharedPreferences) {
+    private var plugins: List<YantraPlugin> = builtInPlugins()
+
+    private val suggestionPlugins: List<SuggestionPlugin>
+        get() = plugins.filterIsInstance<SuggestionPlugin>()
+
+    fun reload() {
+        plugins = builtInPlugins()
+    }
+
+    fun clearSuggestionPlugins(terminal: Terminal) {
+        suggestionPlugins.forEach { plugin ->
+            runCatching {
+                plugin.clear(terminal)
+            }.onFailure { error ->
+                Log.w(TAG, "Plugin ${plugin.id} failed while clearing suggestions.", error)
+            }
+        }
+    }
+
+    fun onSuggestionsUpdated(terminal: Terminal, context: SuggestionPluginContext) {
+        suggestionPlugins
+            .filter { it.isEnabled(preferenceObject) }
+            .forEach { plugin ->
+                runCatching {
+                    plugin.onSuggestionsUpdated(terminal, context)
+                }.onFailure { error ->
+                    Log.w(TAG, "Plugin ${plugin.id} failed while updating suggestions.", error)
+                }
+            }
+    }
+
+    companion object {
+        private const val TAG = "PluginManager"
+        const val HOST_PLUGIN_API_VERSION = 1
+
+        fun builtInPlugins(): List<YantraPlugin> {
+            return PluginCatalog.sourceDistributedPlugins()
+        }
+
+        fun compatibilityFor(plugin: YantraPlugin): PluginCompatibility {
+            return when {
+                plugin.minHostPluginApiVersion > HOST_PLUGIN_API_VERSION -> {
+                    PluginCompatibility(
+                        label = "Needs app update",
+                        detail = "Requires plugin API ${plugin.minHostPluginApiVersion}; app has API $HOST_PLUGIN_API_VERSION.",
+                        canEnable = false
+                    )
+                }
+
+                plugin.targetHostPluginApiVersion < HOST_PLUGIN_API_VERSION -> {
+                    PluginCompatibility(
+                        label = "Legacy",
+                        detail = "Built for plugin API ${plugin.targetHostPluginApiVersion}; app has API $HOST_PLUGIN_API_VERSION.",
+                        canEnable = true
+                    )
+                }
+
+                else -> {
+                    PluginCompatibility(
+                        label = "Compatible",
+                        detail = "Built for plugin API ${plugin.targetHostPluginApiVersion}.",
+                        canEnable = true
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/coderGtm/yantra/plugins/YantraPlugin.kt
+++ b/app/src/main/java/com/coderGtm/yantra/plugins/YantraPlugin.kt
@@ -1,0 +1,62 @@
+package com.coderGtm.yantra.plugins
+
+import android.content.SharedPreferences
+import com.coderGtm.yantra.terminal.Terminal
+
+/**
+ * Small host API for plugins that are contributed through the repository.
+ *
+ * A plugin should keep its implementation in one folder under `plugins/contrib`
+ * and expose one class that implements this interface or a narrower child
+ * interface such as [SuggestionPlugin].
+ */
+interface YantraPlugin {
+    val id: String
+    val name: String
+    val author: String?
+        get() = null
+    val description: String
+    val versionName: String
+    val versionCode: Int
+    val minHostPluginApiVersion: Int
+        get() = 1
+    val targetHostPluginApiVersion: Int
+        get() = minHostPluginApiVersion
+    val capabilities: List<String>
+        get() = emptyList()
+    val defaultEnabled: Boolean
+        get() = true
+    val preferenceKey: String
+        get() = "plugin.$id.enabled"
+
+    fun isEnabled(preferenceObject: SharedPreferences): Boolean {
+        return preferenceObject.getBoolean(preferenceKey, defaultEnabled)
+    }
+}
+
+data class SuggestionPluginContext(
+    val rawInput: String,
+    val input: String,
+    val args: List<String>,
+    val suggestions: List<String>,
+    val isPrimary: Boolean,
+    val overrideLastWord: Boolean
+)
+
+/**
+ * Extension point for plugins that react to terminal suggestions.
+ *
+ * The host owns suggestion generation; plugins can observe that result and add
+ * their own UI or behavior without changing the command parser.
+ */
+interface SuggestionPlugin : YantraPlugin {
+    fun onSuggestionsUpdated(terminal: Terminal, context: SuggestionPluginContext)
+
+    fun clear(terminal: Terminal) = Unit
+}
+
+data class PluginCompatibility(
+    val label: String,
+    val detail: String,
+    val canEnable: Boolean
+)

--- a/app/src/main/java/com/coderGtm/yantra/plugins/contrib/README.md
+++ b/app/src/main/java/com/coderGtm/yantra/plugins/contrib/README.md
@@ -1,0 +1,49 @@
+# Yantra Plugin Contributions
+
+Source-distributed plugins live here. They are reviewed, built, and shipped with Yantra rather than downloaded at runtime.
+
+## Folder Convention
+
+Use one folder per plugin:
+
+```text
+plugins/
+  contrib/
+    <feature>_<githubUsername>_<version>/
+      PluginClass.kt
+      optional_helpers.kt
+      README.md
+      assets/              # optional source-side assets or notes
+```
+
+Example:
+
+```text
+plugins/contrib/autocomplete_yyppsk_v0_1_0/
+```
+
+Use lowercase folder names where possible. Convert semantic versions to Android-friendly names:
+
+```text
+v0.1.0 -> v0_1_0
+```
+
+## Contributor Checklist
+
+1. Create a plugin folder using the naming convention above.
+2. Implement one of the plugin host interfaces from `YantraPlugin.kt`.
+3. Keep plugin-specific helpers, models, and documentation inside your plugin folder.
+4. Set `author` to the GitHub username or team name that owns the contribution.
+5. If runtime assets are needed, place them under `app/src/main/assets/plugins/<plugin_folder>/` and reference that path from your plugin.
+6. Register the plugin in `PluginCatalog.kt`.
+7. Build `freeDebug` and confirm the plugin appears in Settings > Plugins > Manage Your Plugins.
+
+## Review Criteria
+
+Plugins should avoid network calls, storage access, or UI mutation unless the feature clearly needs it. Keep pure logic in small helpers with JVM tests when possible, and prefer host methods over direct access to activity views.
+
+## Local Testing
+
+Run `./gradlew :app:assembleFreeDebug` before opening a PR. If the plugin has pure logic, add tests under `app/src/test/java/...` beside the plugin package and run the matching `testFreeDebugUnitTest` task.
+
+This shape gives GitHub contributors a clear path without opening the app to unreviewed runtime code.

--- a/app/src/main/java/com/coderGtm/yantra/plugins/contrib/autocomplete_yyppsk_v0_1_0/InlineAutocompletePlugin.kt
+++ b/app/src/main/java/com/coderGtm/yantra/plugins/contrib/autocomplete_yyppsk_v0_1_0/InlineAutocompletePlugin.kt
@@ -1,0 +1,70 @@
+package com.coderGtm.yantra.plugins.contrib.autocomplete_yyppsk_v0_1_0
+
+import com.coderGtm.yantra.plugins.SuggestionPlugin
+import com.coderGtm.yantra.plugins.SuggestionPluginContext
+import com.coderGtm.yantra.terminal.Terminal
+
+class InlineAutocompletePlugin : SuggestionPlugin {
+    override val id = ID
+    override val name = "Inline Autocomplete"
+    override val author = "yyppsk"
+    override val description = "Shows a faded inline completion after the command input."
+    override val versionName = "0.1.0"
+    override val versionCode = 1
+    override val minHostPluginApiVersion = 1
+    override val targetHostPluginApiVersion = 1
+    override val capabilities = listOf("Suggestions", "Input UI")
+    override val preferenceKey = PREFERENCE_KEY
+
+    override fun onSuggestionsUpdated(terminal: Terminal, context: SuggestionPluginContext) {
+        val suffix = InlineAutocompleteCompletion.buildSuffix(context)
+        terminal.setInlineCompletion(suffix)
+    }
+
+    override fun clear(terminal: Terminal) {
+        terminal.setInlineCompletion(null)
+    }
+
+    companion object {
+        const val ID = "inline_autocomplete"
+        const val PREFERENCE_KEY = "plugin.inline_autocomplete.enabled"
+    }
+}
+
+internal object InlineAutocompleteCompletion {
+    fun buildSuffix(context: SuggestionPluginContext): String? {
+        if (context.rawInput.isBlank() || context.suggestions.isEmpty()) {
+            return null
+        }
+
+        val suggestion = context.suggestions.firstOrNull {
+            !isCurrentInput(context, it)
+        } ?: return null
+
+        val completedInput = if (context.overrideLastWord) {
+            val lastArg = context.args.lastOrNull().orEmpty()
+            context.input.substring(0, context.input.length - lastArg.length) + suggestion + " "
+        } else {
+            context.input + " " + suggestion + " "
+        }
+
+        if (completedInput.length <= context.rawInput.length) {
+            return null
+        }
+
+        if (!completedInput.startsWith(context.rawInput, ignoreCase = true)) {
+            return null
+        }
+
+        return completedInput.substring(context.rawInput.length)
+    }
+
+    private fun isCurrentInput(context: SuggestionPluginContext, suggestion: String): Boolean {
+        return if (context.isPrimary) {
+            context.input.trim().equals(suggestion.trim(), ignoreCase = true)
+        } else {
+            val secondaryInput = context.input.removePrefix(context.args.firstOrNull().orEmpty()).trim()
+            secondaryInput.equals(suggestion.trim(), ignoreCase = true)
+        }
+    }
+}

--- a/app/src/main/java/com/coderGtm/yantra/plugins/contrib/autocomplete_yyppsk_v0_1_0/README.md
+++ b/app/src/main/java/com/coderGtm/yantra/plugins/contrib/autocomplete_yyppsk_v0_1_0/README.md
@@ -1,0 +1,21 @@
+# Inline Autocomplete
+
+Owner: `yyppsk`
+
+Version: `0.1.0`
+
+Folder id: `autocomplete_yyppsk_v0_1_0`
+
+This plugin observes Yantra's existing suggestion results and renders a faded inline completion inside the terminal input.
+
+## Files
+
+- `InlineAutocompletePlugin.kt`: plugin entrypoint and suggestion handling.
+
+## Assets
+
+This plugin does not require assets. If a future plugin needs packaged assets, place them under:
+
+```text
+app/src/main/assets/plugins/autocomplete_yyppsk_v0_1_0/
+```

--- a/app/src/main/java/com/coderGtm/yantra/terminal/Helper.kt
+++ b/app/src/main/java/com/coderGtm/yantra/terminal/Helper.kt
@@ -18,6 +18,7 @@ import com.coderGtm.yantra.isPro
 import com.coderGtm.yantra.loadPrimarySuggestionsOrder
 import com.coderGtm.yantra.models.Alias
 import com.coderGtm.yantra.models.Suggestion
+import com.coderGtm.yantra.plugins.SuggestionPluginContext
 import com.coderGtm.yantra.requestCmdInputFocusAndShowKeyboard
 import java.util.Locale
 import java.util.regex.Pattern
@@ -32,6 +33,7 @@ fun showSuggestions(
         terminal.activity.runOnUiThread {
             terminal.binding.suggestionsTab.removeAllViews()
         }
+        terminal.pluginManager.clearSuggestionPlugins(terminal)
         val input = rawInput.trim()
         val suggestions = ArrayList<String>()
         val args = input.split(" ")
@@ -620,6 +622,18 @@ fun showSuggestions(
                 }
             }
         }
+        terminal.pluginManager.onSuggestionsUpdated(
+            terminal,
+            SuggestionPluginContext(
+                rawInput = rawInput,
+                input = input,
+                args = args,
+                suggestions = suggestions.toList(),
+                isPrimary = isPrimary,
+                overrideLastWord = overrideLastWord
+            )
+        )
+
         suggestions.forEach { sug ->
             if ((isPrimary && (input.trim() == sug.trim())) || (!isPrimary && (input.removePrefix(args[0]).trim() == sug.trim()))) {
                 return@forEach

--- a/app/src/main/java/com/coderGtm/yantra/terminal/Terminal.kt
+++ b/app/src/main/java/com/coderGtm/yantra/terminal/Terminal.kt
@@ -51,6 +51,7 @@ import com.coderGtm.yantra.models.Alias
 import com.coderGtm.yantra.models.AppBlock
 import com.coderGtm.yantra.models.ShortcutBlock
 import com.coderGtm.yantra.models.Suggestion
+import com.coderGtm.yantra.plugins.PluginManager
 import com.coderGtm.yantra.promoteProVersion
 import com.coderGtm.yantra.requestCmdInputFocusAndShowKeyboard
 import com.coderGtm.yantra.requestUpdateIfAvailable
@@ -79,6 +80,7 @@ class Terminal(
     private var commandCache = mutableListOf<Map<String, BaseCommand>>()
 
     val theme = getCurrentTheme(activity, preferenceObject)
+    val pluginManager = PluginManager(preferenceObject)
     val commands = getAvailableCommands(activity)
     var primarySuggestions: MutableList<Suggestion> = mutableListOf()
     var initialized = false
@@ -98,6 +100,12 @@ class Terminal(
     lateinit var shortcutList: ArrayList<ShortcutBlock>
     lateinit var wakeBtn: TextView
     lateinit var aliasList: MutableList<Alias>
+
+    fun setInlineCompletion(suffix: String?) {
+        activity.runOnUiThread {
+            binding.cmdInput.setInlineCompletion(suffix, theme.inputLineTextColor)
+        }
+    }
 
     fun initialize() {
         if (preferenceObject.getBoolean("useModernPromptDesign", false)) {

--- a/app/src/main/java/com/coderGtm/yantra/terminal/TerminalEditText.kt
+++ b/app/src/main/java/com/coderGtm/yantra/terminal/TerminalEditText.kt
@@ -1,7 +1,12 @@
 package com.coderGtm.yantra.terminal
 
 import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.text.TextPaint
 import android.util.AttributeSet
+import android.view.MotionEvent
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import androidx.appcompat.widget.AppCompatEditText
@@ -12,9 +17,107 @@ class TerminalEditText : AppCompatEditText {
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(context, attrs, defStyle)
 
+    private val inlineCompletionPaint = TextPaint(Paint.ANTI_ALIAS_FLAG)
+    private var inlineCompletionSuffix: String? = null
+    private var inlineCompletionColor: Int = Color.GRAY
+
     override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection? {
         val conn = super.onCreateInputConnection(outAttrs)
         outAttrs.imeOptions = outAttrs.imeOptions and EditorInfo.IME_FLAG_NO_ENTER_ACTION.inv()
         return conn
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        drawInlineCompletion(canvas)
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (event.action == MotionEvent.ACTION_UP && isInlineCompletionTouched(event.x, event.y)) {
+            acceptInlineCompletion()
+            performClick()
+            return true
+        }
+
+        return super.onTouchEvent(event)
+    }
+
+    override fun performClick(): Boolean {
+        super.performClick()
+        return true
+    }
+
+    fun setInlineCompletion(suffix: String?, color: Int = currentTextColor) {
+        val normalizedSuffix = suffix?.takeIf { it.isNotEmpty() }
+        if (inlineCompletionSuffix == normalizedSuffix && inlineCompletionColor == color) {
+            return
+        }
+
+        inlineCompletionSuffix = normalizedSuffix
+        inlineCompletionColor = color
+        invalidate()
+    }
+
+    private fun drawInlineCompletion(canvas: Canvas) {
+        val suffix = inlineCompletionSuffix ?: return
+        val drawPoint = getInlineCompletionDrawPoint() ?: return
+
+        configureInlineCompletionPaint()
+        canvas.drawText(suffix, drawPoint.x, drawPoint.baseline, inlineCompletionPaint)
+    }
+
+    private fun isInlineCompletionTouched(x: Float, y: Float): Boolean {
+        val suffix = inlineCompletionSuffix ?: return false
+        val drawPoint = getInlineCompletionDrawPoint() ?: return false
+
+        configureInlineCompletionPaint()
+        val touchPadding = 12f * resources.displayMetrics.density
+        val lineHeight = lineHeight.toFloat()
+        val suffixWidth = inlineCompletionPaint.measureText(suffix)
+
+        return x >= drawPoint.x - touchPadding &&
+            x <= drawPoint.x + suffixWidth + touchPadding &&
+            y >= drawPoint.baseline - lineHeight &&
+            y <= drawPoint.baseline + touchPadding
+    }
+
+    private fun acceptInlineCompletion() {
+        val suffix = inlineCompletionSuffix ?: return
+        val editable = text ?: return
+        editable.append(suffix)
+        setSelection(editable.length)
+        setInlineCompletion(null)
+    }
+
+    private fun getInlineCompletionDrawPoint(): InlineCompletionDrawPoint? {
+        val editable = text ?: return null
+        val textLayout = layout ?: return null
+        val cursorPosition = selectionStart
+
+        if (!hasFocus() || cursorPosition != selectionEnd || cursorPosition != editable.length) {
+            return null
+        }
+
+        val line = textLayout.getLineForOffset(cursorPosition)
+        val x = compoundPaddingLeft + textLayout.getPrimaryHorizontal(cursorPosition) - scrollX
+        val baseline = extendedPaddingTop + textLayout.getLineBaseline(line).toFloat() - scrollY
+
+        return InlineCompletionDrawPoint(x, baseline)
+    }
+
+    private fun configureInlineCompletionPaint() {
+        inlineCompletionPaint.set(paint)
+        inlineCompletionPaint.color = inlineCompletionColor
+        inlineCompletionPaint.alpha = INLINE_COMPLETION_ALPHA
+        inlineCompletionPaint.style = Paint.Style.FILL
+    }
+
+    private data class InlineCompletionDrawPoint(
+        val x: Float,
+        val baseline: Float
+    )
+
+    companion object {
+        private const val INLINE_COMPLETION_ALPHA = 95
     }
 }

--- a/app/src/main/java/com/coderGtm/yantra/ui/settings/groups/PluginManagerDialog.kt
+++ b/app/src/main/java/com/coderGtm/yantra/ui/settings/groups/PluginManagerDialog.kt
@@ -1,0 +1,184 @@
+package com.coderGtm.yantra.ui.settings.groups
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.coderGtm.yantra.R
+import com.coderGtm.yantra.plugins.PluginManager
+import com.coderGtm.yantra.plugins.YantraPlugin
+import com.coderGtm.yantra.ui.theme.CharcoalDivider2
+import com.coderGtm.yantra.ui.theme.CharcoalOnPrimary
+import com.coderGtm.yantra.ui.theme.CharcoalSilver
+import com.coderGtm.yantra.ui.theme.CharcoalTextMuted
+
+@Composable
+fun PluginManagerDialog(
+    plugins: List<YantraPlugin>,
+    isPluginEnabled: (YantraPlugin) -> Boolean,
+    onPluginEnabledChange: (YantraPlugin, Boolean) -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        title = {
+            Text(text = stringResource(R.string.manage_your_plugins))
+        },
+        text = {
+            Column(
+                modifier = Modifier
+                    .heightIn(max = 460.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                plugins.forEachIndexed { index, plugin ->
+                    PluginManagerRow(
+                        plugin = plugin,
+                        checked = isPluginEnabled(plugin),
+                        onCheckedChange = { onPluginEnabledChange(plugin, it) }
+                    )
+                    if (index != plugins.lastIndex) {
+                        Spacer(modifier = Modifier.height(10.dp))
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(R.string.close))
+            }
+        }
+    )
+}
+
+@Composable
+private fun PluginManagerRow(
+    plugin: YantraPlugin,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    val compatibility = PluginManager.compatibilityFor(plugin)
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(14.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer
+    ) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = plugin.name,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    plugin.author?.takeIf { it.isNotBlank() }?.let { author ->
+                        Spacer(modifier = Modifier.height(2.dp))
+                        Text(
+                            text = stringResource(R.string.plugin_author_label, author),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = CharcoalTextMuted
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.width(12.dp))
+                Switch(
+                    checked = checked && compatibility.canEnable,
+                    enabled = compatibility.canEnable,
+                    onCheckedChange = onCheckedChange,
+                    colors = SwitchDefaults.colors(
+                        checkedTrackColor = CharcoalSilver,
+                        checkedThumbColor = CharcoalOnPrimary,
+                        checkedBorderColor = CharcoalSilver,
+                        uncheckedTrackColor = CharcoalDivider2,
+                        uncheckedThumbColor = CharcoalTextMuted,
+                        uncheckedBorderColor = CharcoalTextMuted,
+                    )
+                )
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 9.dp))
+
+            Text(
+                text = plugin.description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 9.dp))
+
+            Row {
+                PluginInfoPill(text = stringResource(R.string.plugin_version_pill, plugin.versionName))
+                Spacer(modifier = Modifier.width(6.dp))
+                PluginInfoPill(
+                    text = compatibility.label,
+                    isPositive = compatibility.canEnable
+                )
+            }
+
+            if (plugin.capabilities.isNotEmpty()) {
+                HorizontalDivider(modifier = Modifier.padding(vertical = 9.dp))
+
+                Row {
+                    plugin.capabilities.forEachIndexed { index, capability ->
+                        PluginInfoPill(text = capability)
+                        if (index != plugin.capabilities.lastIndex) {
+                            Spacer(modifier = Modifier.width(6.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PluginInfoPill(
+    text: String,
+    isPositive: Boolean = false
+) {
+    Surface(
+        shape = RoundedCornerShape(50),
+        color = if (isPositive) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerHighest
+        }
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            color = if (isPositive) {
+                MaterialTheme.colorScheme.onPrimaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/coderGtm/yantra/ui/settings/groups/PluginsGroup.kt
+++ b/app/src/main/java/com/coderGtm/yantra/ui/settings/groups/PluginsGroup.kt
@@ -1,0 +1,23 @@
+package com.coderGtm.yantra.ui.settings.groups
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.coderGtm.yantra.R
+import com.coderGtm.yantra.ui.components.containers.SettingsGroup
+import com.coderGtm.yantra.ui.components.settingsItem.OptionSetting
+
+@Composable
+fun PluginsGroup(
+    enabledPluginCount: Int,
+    installedPluginCount: Int,
+    onOpenPluginManager: () -> Unit
+) {
+    SettingsGroup(title = stringResource(R.string.plugins)) {
+        OptionSetting(
+            title = stringResource(R.string.manage_your_plugins),
+            description = stringResource(R.string.plugin_manager_description),
+            value = stringResource(R.string.plugin_count_summary, enabledPluginCount, installedPluginCount),
+            onClick = onOpenPluginManager
+        )
+    }
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -736,6 +736,12 @@
     <string name="font">Fuente</string>
     <string name="arrow_keys">Teclas de Flecha</string>
     <string name="suggestions">Sugerencias</string>
+    <string name="plugins">Plugins</string>
+    <string name="manage_your_plugins">Gestionar plugins</string>
+    <string name="plugin_manager_description">Activa o desactiva plugins y comprueba su estado.</string>
+    <string name="plugin_count_summary">%1$d/%2$d activados</string>
+    <string name="plugin_version_pill">v%1$s</string>
+    <string name="plugin_author_label">Por %1$s</string>
     <string name="gestures">Gestos</string>
     <string name="keyboard">Teclado</string>
     <string name="advanced">Avanzado</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -740,6 +740,12 @@
     <string name="font">Carattere</string>
     <string name="arrow_keys">Tasti Freccia</string>
     <string name="suggestions">Suggerimenti</string>
+    <string name="plugins">Plugin</string>
+    <string name="manage_your_plugins">Gestisci i plugin</string>
+    <string name="plugin_manager_description">Attiva o disattiva i plugin e controlla il loro stato.</string>
+    <string name="plugin_count_summary">%1$d/%2$d attivi</string>
+    <string name="plugin_version_pill">v%1$s</string>
+    <string name="plugin_author_label">Di %1$s</string>
     <string name="gestures">Gesti</string>
     <string name="keyboard">Tastiera</string>
     <string name="advanced">Avanzate</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -738,6 +738,12 @@
     <string name="font">Шрифт</string>
     <string name="arrow_keys">Клавиши-стрелки</string>
     <string name="suggestions">Подсказки</string>
+    <string name="plugins">Плагины</string>
+    <string name="manage_your_plugins">Управление плагинами</string>
+    <string name="plugin_manager_description">Включайте или отключайте плагины и проверяйте их состояние.</string>
+    <string name="plugin_count_summary">%1$d/%2$d включено</string>
+    <string name="plugin_version_pill">v%1$s</string>
+    <string name="plugin_author_label">Автор: %1$s</string>
     <string name="gestures">Жесты</string>
     <string name="keyboard">Клавиатура</string>
     <string name="advanced">Дополнительно</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -740,6 +740,12 @@
     <string name="font">Фонт</string>
     <string name="arrow_keys">Тастери са стрелицом</string>
     <string name="suggestions">Предлози</string>
+    <string name="plugins">Додаци</string>
+    <string name="manage_your_plugins">Управљај додацима</string>
+    <string name="plugin_manager_description">Укључите или искључите додатке и проверите њихов статус.</string>
+    <string name="plugin_count_summary">%1$d/%2$d укључено</string>
+    <string name="plugin_version_pill">v%1$s</string>
+    <string name="plugin_author_label">Аутор: %1$s</string>
     <string name="gestures">Гесте</string>
     <string name="keyboard">Тастатура</string>
     <string name="advanced">Напредно</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -738,6 +738,12 @@
     <string name="font">Шрифт</string>
     <string name="arrow_keys">Клавіші зі стрілками</string>
     <string name="suggestions">Підказки</string>
+    <string name="plugins">Плагіни</string>
+    <string name="manage_your_plugins">Керування плагінами</string>
+    <string name="plugin_manager_description">Вмикайте або вимикайте плагіни та перевіряйте їхній стан.</string>
+    <string name="plugin_count_summary">%1$d/%2$d увімкнено</string>
+    <string name="plugin_version_pill">v%1$s</string>
+    <string name="plugin_author_label">Автор: %1$s</string>
     <string name="gestures">Жести</string>
     <string name="keyboard">Клавіатура</string>
     <string name="advanced">Додатково</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -740,6 +740,12 @@
     <string name="font">Font</string>
     <string name="arrow_keys">Arrow Keys</string>
     <string name="suggestions">Suggestions</string>
+    <string name="plugins">Plugins</string>
+    <string name="manage_your_plugins">Manage Your Plugins</string>
+    <string name="plugin_manager_description">Turn plugins on or off and check their status.</string>
+    <string name="plugin_count_summary">%1$d/%2$d enabled</string>
+    <string name="plugin_version_pill">v%1$s</string>
+    <string name="plugin_author_label">By %1$s</string>
     <string name="gestures">Gestures</string>
     <string name="keyboard">Keyboard</string>
     <string name="advanced">Advanced</string>

--- a/app/src/test/java/com/coderGtm/yantra/plugins/contrib/autocomplete_yyppsk_v0_1_0/InlineAutocompleteCompletionTest.kt
+++ b/app/src/test/java/com/coderGtm/yantra/plugins/contrib/autocomplete_yyppsk_v0_1_0/InlineAutocompleteCompletionTest.kt
@@ -1,0 +1,121 @@
+package com.coderGtm.yantra.plugins.contrib.autocomplete_yyppsk_v0_1_0
+
+import com.coderGtm.yantra.plugins.SuggestionPluginContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class InlineAutocompleteCompletionTest {
+
+    @Test
+    fun `buildSuffix completes a partial primary command`() {
+        val result = InlineAutocompleteCompletion.buildSuffix(
+            context(
+                rawInput = "la",
+                input = "la",
+                args = listOf("la"),
+                suggestions = listOf("launch"),
+                isPrimary = true,
+                overrideLastWord = true
+            )
+        )
+
+        assertEquals("unch ", result)
+    }
+
+    @Test
+    fun `buildSuffix completes the current secondary argument`() {
+        val result = InlineAutocompleteCompletion.buildSuffix(
+            context(
+                rawInput = "launch -",
+                input = "launch -",
+                args = listOf("launch", "-"),
+                suggestions = listOf("-p"),
+                isPrimary = false,
+                overrideLastWord = true
+            )
+        )
+
+        assertEquals("p ", result)
+    }
+
+    @Test
+    fun `buildSuffix appends a secondary suggestion after a completed command`() {
+        val result = InlineAutocompleteCompletion.buildSuffix(
+            context(
+                rawInput = "launch",
+                input = "launch",
+                args = listOf("launch"),
+                suggestions = listOf("-p"),
+                isPrimary = false,
+                overrideLastWord = false
+            )
+        )
+
+        assertEquals(" -p ", result)
+    }
+
+    @Test
+    fun `buildSuffix skips suggestions that already match current input`() {
+        val result = InlineAutocompleteCompletion.buildSuffix(
+            context(
+                rawInput = "launch",
+                input = "launch",
+                args = listOf("launch"),
+                suggestions = listOf("launch"),
+                isPrimary = true,
+                overrideLastWord = true
+            )
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `buildSuffix returns null when completion does not continue raw input`() {
+        val result = InlineAutocompleteCompletion.buildSuffix(
+            context(
+                rawInput = "foo",
+                input = "bar",
+                args = listOf("bar"),
+                suggestions = listOf("baz"),
+                isPrimary = true,
+                overrideLastWord = true
+            )
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `buildSuffix returns null for blank input or empty suggestions`() {
+        assertNull(
+            InlineAutocompleteCompletion.buildSuffix(
+                context(rawInput = " ", input = "", args = emptyList(), suggestions = listOf("launch"))
+            )
+        )
+        assertNull(
+            InlineAutocompleteCompletion.buildSuffix(
+                context(rawInput = "la", input = "la", args = listOf("la"), suggestions = emptyList())
+            )
+        )
+    }
+
+    private fun context(
+        rawInput: String,
+        input: String,
+        args: List<String>,
+        suggestions: List<String>,
+        isPrimary: Boolean = true,
+        overrideLastWord: Boolean = true
+    ): SuggestionPluginContext {
+        return SuggestionPluginContext(
+            rawInput = rawInput,
+            input = input,
+            args = args,
+            suggestions = suggestions,
+            isPrimary = isPrimary,
+            overrideLastWord = overrideLastWord
+        )
+    }
+}


### PR DESCRIPTION
This PR introduces a source-distributed plugin system for Yantra Launcher and adds inline autocomplete as the first plugin implementation.

Closes: #512

**What Changed**

- Added a reviewed, source-distributed plugin architecture without runtime code downloading.
- Added plugin metadata, compatibility checks, enable/disable preference handling, and defensive callback handling.
- Added a Plugin Manager entry in Settings with toggles, version/status pills, capability pills, and contributor attribution.
- Added contributor-friendly plugin folder structure:
  `plugins/contrib/<feature>_<githubUsername>_<version>/`
- Added the first contrib plugin:
  `autocomplete_yyppsk_v0_1_0`
- Added faded inline command completion in the terminal input, accepted by tapping the inline suggestion.
- Added JVM tests for autocomplete suffix generation.
- Added localized strings for the new plugin manager UI.
- Aligned Java/Kotlin compilation target to JVM 11 so existing unit tests compile with current test dependencies.


**Screenshots**

### Command Autocomplete

<img width="50%" height="1140" alt="share_1642806944720471051" src="https://github.com/user-attachments/assets/f37598e0-79eb-4be5-af9c-3a05df1663ec" />

### Settings View

<img width="50%" height="616" alt="share_75559971379162228" src="https://github.com/user-attachments/assets/188a8cc5-5759-486d-94d1-59e6df3ee1b3" />

### Plugin Manager View
<img width="50%" height="1671" alt="share_566992974135079492" src="https://github.com/user-attachments/assets/342c0d2e-7e47-4cd4-b433-b24fa478fee0" />

---

**Validation**

- `./gradlew :app:testFreeDebugUnitTest`
- `./gradlew :app:assembleFreeDebug`

**Lint Note**

`./gradlew :app:lintFreeDebug` still fails on existing non-plugin issues:
- missing `POST_NOTIFICATIONS` handling in notify command
- missing `ACCESS_NETWORK_STATE` lint check in `Utils.kt`
- existing Spanish/Italian `cmd_todo_help` formatting issues

The plugin-related lint findings from this PR were addressed.